### PR TITLE
chore: Release workflow fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - uses: actions/setup-node@v2
       - run: |
           npm install semantic-release semantic-release/git semantic-release/exec


### PR DESCRIPTION
### :pencil: Description

Removes `secrets.GH_PERSONAL_ACCESS_TOKEN` to address failure in Release workflow checkout
