### PR TITLE
docs: Add docs calling out the breaking change aligning with Spinnake…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The action sends the following information in the payload:
 
 ### Additional Parameters
 
-To pass additional parameters to the pipeline execution context, include the `parameters` input. Each key/value pair will be passed to Spinnaker and can be used in pipeline steps.
+To pass additional parameters to the pipeline execution context, include the `parameters` input. Each key/value pair will be passed as strings to Spinnaker and can be used in pipeline steps.
 
 ```yaml
 steps:
@@ -55,7 +55,24 @@ steps:
       topic_arn: ${{ secrets.SPINNAKER_TOPIC_ARN }}
       parameters: |
         parameter1: value1
+        parameter2: value2
 ```
+
+> [!IMPORTANT]
+> **Breaking change (v1.2.4):**
+> All parameter values are now strings, aligning with [Spinnaker's parameter model](https://spinnaker.io/docs/reference/pipeline/expressions/#comparisons).
+> Previously, values like `true` or `42` were sent as JSON booleans/numbers due to implicit YAML type coercion.
+> If your Spinnaker SpEL expressions compare parameters to non-string types, update them:
+>
+> ```
+> # Before (no longer works)
+> ${parameters.myParameter == true}
+>
+> # After (use string comparison or Spinnaker's type helpers)
+> ${parameters.myParameter == 'true'}
+> ${#toBoolean(parameters.myParameter) == true}
+> ```
+
 
 Parameters are automatically added to `Parameters` of the pipeline. There is no need to define them separately.
 


### PR DESCRIPTION
…r's parameter string type, add fix instructions

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally. - Only README change 
* [ ] There are new or updated unit tests validating the change. - Only README change

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/new-project/blob/master/CONTRIBUTING.md
-->

### :pencil: Description

Add docs calling out the breaking change in `v1.2.4` aligning with Spinnaker's parameter model (only string types) and link to Spinnaker doc.
Add fix instructions.


### :link: Related Issues

https://github.com/ExpediaGroup/spinnaker-pipeline-trigger/pull/479
